### PR TITLE
Added example for TCP Option Extended Data Offset

### DIFF
--- a/ExtendedDataOffset/main_edo.cpp
+++ b/ExtendedDataOffset/main_edo.cpp
@@ -1,0 +1,50 @@
+/*
+* ExtendedDataOffset
+*
+* Create/Parse packets with an EDO TCP option
+* @author : Julien Colmonts
+* */
+#include <iostream>
+#include <string>
+#include <crafter.h>
+
+using namespace std;
+using namespace Crafter;
+
+int main() {
+    /* Create an IP header */
+    IP ip_header;
+    /* Set the Source and Destination IP address */
+    ip_header.SetSourceIP("192.168.0.1");
+    ip_header.SetDestinationIP("192.168.0.4");
+    
+    /* Dummy TCP header */
+    TCP tcp_header;
+
+    /* Set the source and destination ports */
+    tcp_header.SetSrcPort(RNG16());
+    tcp_header.SetDstPort(22);
+    tcp_header.SetSeqNumber(RNG32());
+    //tcp_header.SetFlags(TCP::SYN);
+
+    /* EDO size option */
+    TCPOptionExtendedDataOffset edo;
+
+    /* Dummy Payload */
+    RawLayer payload("Hello World!");
+    
+    /* Create a packet... */
+    Packet packet = ip_header / tcp_header /  TCPOption::NOP /TCPOption::NOP / edo  / TCPOption::NOP /TCPOption::NOP / TCPOption::NOP /TCPOption::NOP / payload;
+    packet.PreCraft();
+    cout << "Original packet:" << endl;
+    packet.Print();
+    packet.HexDump();
+    
+    /* Decode it */
+    Packet decoded;
+    decoded.Decode(packet.GetRawPtr(), packet.GetSize(), IP::PROTO);
+    cout << "Decoded packet:" << endl;
+    decoded.Print();
+    
+    return 0;
+}

--- a/ExtendedDataOffset/main_req.cpp
+++ b/ExtendedDataOffset/main_req.cpp
@@ -1,0 +1,50 @@
+/*
+* ExtendedDataOffset
+*
+* Create/Parse packets with an EDO Request TCP option flagged to SYN
+* @author : Julien Colmonts
+* */
+#include <iostream>
+#include <string>
+#include <crafter.h>
+
+using namespace std;
+using namespace Crafter;
+
+int main() {
+    /* Create an IP header */
+    IP ip_header;
+    /* Set the Source and Destination IP address */
+    ip_header.SetSourceIP("192.168.0.1");
+    ip_header.SetDestinationIP("192.168.0.4");
+    
+    /* Dummy TCP header */
+    TCP tcp_header;
+
+    /* Set the source and destination ports */
+    tcp_header.SetSrcPort(RNG16());
+    tcp_header.SetDstPort(22);
+    tcp_header.SetSeqNumber(RNG32());
+    tcp_header.SetFlags(TCP::SYN);
+
+    /* EDO size option */
+    TCPOptionExtendedDataOffsetRequest edo;
+
+
+    /* Dummy Payload */
+    RawLayer payload("Hello World!");
+    
+    /* Create a packet... */
+    Packet packet = ip_header / tcp_header /  edo /  TCPOption::NOP /TCPOption::NOP /payload;
+    packet.PreCraft();
+    cout << "Original packet:" << endl;
+    packet.Print();
+    
+    /* Decode it */
+    Packet decoded;
+    decoded.Decode(packet.GetRawPtr(), packet.GetSize(), IP::PROTO);
+    cout << "Decoded packet:" << endl;
+    decoded.Print();
+    
+    return 0;
+}


### PR DESCRIPTION
I added examples to test TCP Option Extended Data Offset.
See : https://datatracker.ietf.org/doc/draft-touch-tcpm-tcp-edo/ 